### PR TITLE
voluptous version bump from 0.11.7 to 0.12.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -35,7 +35,7 @@ setup(
     ],
     install_requires=[
         'XBlock',
-        'voluptuous==0.11.7',
+        'voluptuous==0.12.0',
         'web-fragments==0.3.2',
     ],
     entry_points={


### PR DESCRIPTION
**Description:**
This PR upgrades the version of voluptous to match koa release

**JIRA:**
https://edlyio.atlassian.net/browse/EDLY-5749